### PR TITLE
Update halo2curves version to 0.5.0

### DIFF
--- a/poseidon-node/Cargo.toml
+++ b/poseidon-node/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 poseidon-rs = { path = "../poseidon" }
-halo2curves = { version = "0.4.0", git = "https://github.com/privacy-scaling-explorations/halo2curves.git" }
+halo2curves = { version = "0.5.0", git = "https://github.com/privacy-scaling-explorations/halo2curves.git" }
 hex = "0.4.3"
 
 [dependencies.neon]

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon-rs"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["arnaucube <root@arnaucube.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", default-features = false }
 #     "std",
 #     "derive",
 # ] }
-halo2curves = { version = "0.4.0", git = "https://github.com/privacy-scaling-explorations/halo2curves.git", default-features = false }
+halo2curves = { version = "0.5.0", git = "https://github.com/privacy-scaling-explorations/halo2curves.git", default-features = false }
 # rand = { version = "0.8.5", default-features = false }
 once_cell = "1.18.0"
 thiserror = "1.0.43"


### PR DESCRIPTION
# WHAT
Updated ```halo2curves``` version to 0.5.0.

# WHY
PSE team updated updated version of halo2curves to 0.5.0.  That's why I got an error when I tried to build. This PR opened to fix that.

<img width="1278" alt="image" src="https://github.com/SoraSuegami/poseidon-rs/assets/73793382/574e4afb-c1fc-480e-bfdc-c2877758fb57">
